### PR TITLE
Smaller Micro API image

### DIFF
--- a/micro_api/Dockerfile
+++ b/micro_api/Dockerfile
@@ -1,17 +1,28 @@
 # Using Node 20
-FROM node:20
+FROM node:20 as base
 WORKDIR /app
 
-# Install dependencies
-COPY package.json /app 
-COPY yarn.lock /app
-COPY tsconfig.json /app 
-COPY src /app/src
-RUN yarn install 
+COPY . .
 
-# Compile & build
-RUN yarn compile
+RUN yarn set version berry
+RUN yarn install
 
-# Run Micro
-CMD ["npx", "micro", "./build/index.js"]
+# Build code
+FROM base as builder
+WORKDIR /app
+RUN yarn build
+
+# Install prod dependencies
+FROM base as dependencies
+WORKDIR /app
+RUN yarn workspaces focus --production
+
+FROM gcr.io/distroless/nodejs20-debian11
+WORKDIR /app
+COPY --from=builder /app/build ./build
+COPY --from=dependencies /app/node_modules ./node_modules
+
 EXPOSE 3000
+
+CMD ["./build/index.js"]
+

--- a/micro_api/package.json
+++ b/micro_api/package.json
@@ -17,12 +17,11 @@
   },
   "main": "build/src/index.js",
   "scripts": {
-    "precompile": "yarn clean",
-    "compile": "npx tsc",
-    "prestart": "yarn compile",
-    "start": "npx micro ./build/src/index.js",
-    "predev": "yarn compile",
-    "dev": "npx micro-dev ./build/src/index.js",
+    "prebuild": "yarn clean",
+    "build": "npx tsc",
+    "prestart": "yarn build",
+    "start": "node ./build/src/index.js",
+    "predev": "yarn build",
     "test": "npx mocha --bail",
     "clean": "rm -rf ./build"
   },

--- a/micro_api/src/index.ts
+++ b/micro_api/src/index.ts
@@ -1,9 +1,11 @@
 // load env variables (put this at top)
 import "dotenv/config";
 
+import http from "http";
 import { Redis } from "ioredis";
 import { existsSync, readFileSync } from "fs";
 import { SDK } from "hollowdb";
+import { serve } from "micro";
 import type { JWKInterface } from "warp-contracts";
 
 import makeServer from "./server";
@@ -30,5 +32,6 @@ const warp = makeWarp(caches);
 
 const hollowdb = new SDK(wallet, contractTxId, warp);
 
-// module.exports needed by Micro
-module.exports = makeServer(hollowdb, contractTxId);
+const server = new http.Server(serve(makeServer(hollowdb, contractTxId)));
+
+server.listen(3000);


### PR DESCRIPTION
- Resolves #12 by reducing the image size from 712MB to 127MB (compressed).
- Also changed the Micro start-up logic by using Node instead of `npx micro` so that we can use a distroless Node image.
